### PR TITLE
Add manual dry mass support to trajectory calculations

### DIFF
--- a/docs/script.js
+++ b/docs/script.js
@@ -509,8 +509,23 @@ function computeTrajectory() {
     const cTimesRapidityPerLeg = SPEED_OF_LIGHT * rapidityPerLeg;
     const cTimesRapidityTotal = SPEED_OF_LIGHT * rapidityTotal;
 
-    const dryMassOption = MASS_OPTIONS[Number(dryMassRange.value)] ?? MASS_OPTIONS[0];
-    const dryMassKg = dryMassOption.tons * TON_IN_KG;
+    let dryMassKg;
+    const dryMassManualRaw = dryMassManual.value.trim();
+    if (dryMassManualRaw) {
+        const manualTons = Number(dryMassManualRaw);
+        if (!Number.isFinite(manualTons) || manualTons <= 0) {
+            const message = "Manual dry mass must be a positive number.";
+            setMassWarning(message, "#ff5d5d");
+            showFormMessage(message, true);
+            resetResults();
+            return;
+        }
+        setMassWarning("");
+        dryMassKg = manualTons * TON_IN_KG;
+    } else {
+        const dryMassOption = MASS_OPTIONS[Number(dryMassRange.value)] ?? MASS_OPTIONS[0];
+        dryMassKg = dryMassOption.tons * TON_IN_KG;
+    }
     const massRatioHalf = Math.exp(rapidityPerLeg);
     const massRatioTotal = Math.exp(rapidityTotal);
     const totalMassKg = dryMassKg * massRatioTotal;


### PR DESCRIPTION
## Summary
- validate manual dry mass entries and show appropriate form and field warnings when invalid
- use a valid manual dry mass for all trajectory mass and fuel calculations before updating the UI
- keep the dry mass display consistent with the manual or slider source used in the computation

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d90a47a0488333962f814b183026e7